### PR TITLE
Remove `junit-platform-launcher` dependency.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation("ej.api:bon:1.4.4")
 
     //Uncomment the microejVee dependency to set the VEE Port or Kernel to use
-    //microejVee("com.mycompany:myvee:1.0.0")
+    //testMicroejVee("com.mycompany:myvee:1.0.0")
 }
 
 testing {
@@ -24,7 +24,6 @@ testing {
                 implementation("ej.api:edc:1.3.7")
                 implementation("ej.api:bon:1.4.4")
                 implementation("ej.library.test:junit:1.11.0")
-                implementation("org.junit.platform:junit-platform-launcher:1.8.2")
             }
         }
     }


### PR DESCRIPTION
This dependency is not needed anymore since version `1.1.0`. We also replace microejVee configuration with testMicroejVee.